### PR TITLE
Update the index of the semicolon after truncating the line starting with a semicolon

### DIFF
--- a/CSSCompare/Program.cs
+++ b/CSSCompare/Program.cs
@@ -269,12 +269,18 @@ namespace SPBert.CSSCompare
             int semicolon = currentLine.IndexOf(";");
             while (semicolon > -1 && !string.IsNullOrEmpty(currentLine))
             {
-                // Handle empty lines.
+                // Handle lines starting with a semicolon.
                 if (semicolon == 0) {
                     if (currentLine.Length > 1)
+                    {
                         currentLine = currentLine.Substring(1);
+                        semicolon = currentLine.IndexOf(";");
+                        continue;
+                    }
                     else
+                    {
                         return;
+                    }
                 }
 
                 if (semicolon < currentLine.Length - 1)


### PR DESCRIPTION
Hi. This project is great and thank you for your work.

I found an issue with string handling and tried to fix it. Please review and test the changes.

### For testing

File `v1.css`:

```css
selector {
    property_0:value_0;property_1:value_1
}
```

File `v2.css` is empty.

Output:

```console
> .\CSSCompare.exe -v1 .\v1.css -v2 .\v2.css
selector{
        property_0:value_0
        p
        property_1:value_1
}
```

After applying the changes:

```console
> .\CSSCompare.exe -v1 .\v1.css -v2 .\v2.css
selector{
        property_0:value_0
        property_1:value_1
}
```